### PR TITLE
1. Add multi-record traffic search.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1.14" }
 anyhow = "1.0.71"
 axum = "0.6.18"
 serde_json = "1.0.97"


### PR DESCRIPTION
Iterate over cursor and add traffic to vec.
Initially kept in the handle_traffic func.

Todo:
- Seperate router, service, db.
- Pagination - unresponsive on large search.
- Subset of traffic instead of full stuct.